### PR TITLE
Close Scanner in code

### DIFF
--- a/spec/src/main/java/cloud/xcan/angus/spec/process/ProcessCommand.java
+++ b/spec/src/main/java/cloud/xcan/angus/spec/process/ProcessCommand.java
@@ -147,17 +147,18 @@ public final class ProcessCommand {
     boolean execSuccess = true;
     List<String> result = new ArrayList<>();
     try {
-      Scanner s = new Scanner(p.getInputStream(), UTF_8).useDelimiter(System.lineSeparator());
-      while (s.hasNext()) {
-        result.add(s.next());
+      try (Scanner s = new Scanner(p.getInputStream(), UTF_8).useDelimiter(System.lineSeparator())) {
+                while (s.hasNext()) {
+                  result.add(s.next());
+                }
+                // Block the current thread until the child process completes execution.
+                exitCode = p.waitFor();
+              } catch (Exception e) {
+                log.error("Problem reading output by command `{}`: {}", Arrays.toString(cmdToRunWithArgs),
+                    e.getMessage());
+                execSuccess = false;
+                result.add(e.getMessage());
       }
-      // Block the current thread until the child process completes execution.
-      exitCode = p.waitFor();
-    } catch (Exception e) {
-      log.error("Problem reading output by command `{}`: {}", Arrays.toString(cmdToRunWithArgs),
-          e.getMessage());
-      execSuccess = false;
-      result.add(e.getMessage());
     }
     boolean success = execSuccess && exitCode == 0;
     if (onlyMatchSuccessMessage) {


### PR DESCRIPTION
Spotted something in spec/src/main/java/cloud/xcan/angus/spec/process/ProcessCommand.java that might be worth a look: The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path — happy to close if this isn’t useful.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.